### PR TITLE
Fix unified tags fetching, diagnostics, and caching

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  Cache-Control: no-cache
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/services/tags/unifiedTags.ts
+++ b/src/services/tags/unifiedTags.ts
@@ -1,0 +1,112 @@
+import type { Smol } from "../../types/domain";
+import { getGlobalSnapshot, mergeSmolsWithSnapshot } from "../api/snapshot";
+import { safeFetchSmols } from "../api/smols";
+import {
+  buildTagStats,
+  mergeTagStats,
+  sortTagStats,
+} from "../../utils/tagStats";
+
+export type TagSortMode =
+  | "popularity"
+  | "frequency"
+  | "alphabetical"
+  | "recent";
+
+export type TagDataSource = "snapshot" | "snapshot+live";
+
+export interface TagStat {
+  tag: string;
+  key: string;
+  count: number;
+  popularity: number;
+  latest?: string;
+}
+
+export interface TagMeta {
+  snapshotTagsCount: number;
+  liveTagsCount: number;
+  finalTagsCount: number;
+  dataSourceUsed: TagDataSource;
+}
+
+async function fetchLiveSmols(): Promise<Smol[]> {
+  try {
+    const smols = await safeFetchSmols();
+    return Array.isArray(smols) ? smols : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getSnapshotTagStats(): { tags: TagStat[]; meta: TagMeta } {
+  const snapshotSmols = getGlobalSnapshot();
+  const snapshotTags = buildTagStats(snapshotSmols) as TagStat[];
+
+  return {
+    tags: snapshotTags,
+    meta: {
+      snapshotTagsCount: snapshotTags.length,
+      liveTagsCount: 0,
+      finalTagsCount: snapshotTags.length,
+      dataSourceUsed: "snapshot",
+    },
+  };
+}
+
+export async function getUnifiedTags(options?: {
+  liveSmols?: Smol[];
+}): Promise<{
+  tags: TagStat[];
+  meta: TagMeta;
+}> {
+  const snapshotSmols = getGlobalSnapshot();
+  const snapshotTags = buildTagStats(snapshotSmols) as TagStat[];
+
+  const liveSmols =
+    options?.liveSmols && options.liveSmols.length > 0
+      ? options.liveSmols
+      : await fetchLiveSmols();
+  const liveTags = buildTagStats(liveSmols) as TagStat[];
+
+  let mergedSmols = snapshotSmols;
+  let dataSourceUsed: TagDataSource = "snapshot";
+
+  if (liveSmols.length > 0) {
+    mergedSmols = mergeSmolsWithSnapshot(liveSmols);
+    dataSourceUsed = "snapshot+live";
+  }
+
+  const mergedTags = buildTagStats(mergedSmols) as TagStat[];
+  const finalTags = mergeTagStats(snapshotTags, mergedTags) as TagStat[];
+
+  const tags =
+    finalTags.length >= snapshotTags.length ? finalTags : snapshotTags;
+
+  return {
+    tags,
+    meta: {
+      snapshotTagsCount: snapshotTags.length,
+      liveTagsCount: liveTags.length,
+      finalTagsCount: tags.length,
+      dataSourceUsed,
+    },
+  };
+}
+
+export function shouldLogTagDiagnostics(): boolean {
+  if (import.meta.env.DEV) return true;
+  if (typeof window === "undefined") return false;
+
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("debug") === "1") return true;
+  } catch {
+    // ignore
+  }
+
+  const host = window.location.hostname;
+  return host === "localhost" || host === "127.0.0.1";
+}
+
+export { sortTagStats };

--- a/src/utils/tagStats.js
+++ b/src/utils/tagStats.js
@@ -1,0 +1,132 @@
+/**
+ * @typedef {import("../types/domain").Smol} Smol
+ */
+
+/**
+ * @typedef {Object} TagStat
+ * @property {string} tag
+ * @property {string} key
+ * @property {number} count
+ * @property {number} popularity
+ * @property {string} [latest]
+ */
+
+/**
+ * Normalize a tag key for dedupe.
+ * @param {string} tag
+ * @returns {string}
+ */
+export function normalizeTagKey(tag) {
+  return tag.trim().toLowerCase();
+}
+
+/**
+ * Extract unique tags for a smol entry.
+ * @param {Smol} smol
+ * @returns {string[]}
+ */
+export function extractSmolTags(smol) {
+  const tags = new Set();
+
+  if (smol.Tags) {
+    smol.Tags.forEach((tag) => tags.add(tag));
+  }
+  if (smol.lyrics?.style) {
+    smol.lyrics.style.forEach((tag) => tags.add(tag));
+  }
+
+  return Array.from(tags)
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+/**
+ * Build tag stats from smols.
+ * @param {Smol[]} smols
+ * @returns {TagStat[]}
+ */
+export function buildTagStats(smols) {
+  const stats = new Map();
+
+  smols.forEach((smol) => {
+    const date = smol.Created_At || "1970-01-01";
+    const weight = (smol.Plays || 0) + (smol.Views || 0) * 0.1;
+
+    extractSmolTags(smol).forEach((tag) => {
+      const key = normalizeTagKey(tag);
+      if (!key) return;
+
+      const existing = stats.get(key);
+      if (existing) {
+        existing.count += 1;
+        existing.popularity += weight;
+        if (!existing.latest || date > existing.latest) {
+          existing.latest = date;
+        }
+      } else {
+        stats.set(key, {
+          tag,
+          key,
+          count: 1,
+          popularity: weight,
+          latest: date,
+        });
+      }
+    });
+  });
+
+  return Array.from(stats.values()).map((stat) => ({
+    ...stat,
+    popularity: Math.round(stat.popularity),
+  }));
+}
+
+/**
+ * Merge tag stats without shrinking the base set.
+ * @param {TagStat[]} baseTags
+ * @param {TagStat[]} incomingTags
+ * @returns {TagStat[]}
+ */
+export function mergeTagStats(baseTags, incomingTags) {
+  const merged = new Map();
+
+  baseTags.forEach((tag) => {
+    merged.set(tag.key || normalizeTagKey(tag.tag), { ...tag });
+  });
+
+  incomingTags.forEach((tag) => {
+    const key = tag.key || normalizeTagKey(tag.tag);
+    const existing = merged.get(key);
+    merged.set(key, {
+      ...tag,
+      key,
+      tag: existing?.tag || tag.tag,
+    });
+  });
+
+  return Array.from(merged.values());
+}
+
+/**
+ * Sort tags without filtering.
+ * @param {TagStat[]} tags
+ * @param {"popularity" | "frequency" | "alphabetical" | "recent"} mode
+ * @returns {TagStat[]}
+ */
+export function sortTagStats(tags, mode) {
+  const sorted = [...tags];
+
+  if (mode === "popularity") {
+    sorted.sort(
+      (a, b) => b.popularity - a.popularity || b.count - a.count,
+    );
+  } else if (mode === "alphabetical") {
+    sorted.sort((a, b) => a.tag.localeCompare(b.tag));
+  } else if (mode === "recent") {
+    sorted.sort((a, b) => (b.latest || "").localeCompare(a.latest || ""));
+  } else {
+    sorted.sort((a, b) => b.count - a.count);
+  }
+
+  return sorted;
+}

--- a/tests/tagStats.test.js
+++ b/tests/tagStats.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildTagStats,
+  mergeTagStats,
+  normalizeTagKey,
+  sortTagStats,
+} from "../src/utils/tagStats.js";
+
+test("buildTagStats dedupes tags by normalized key", () => {
+  const smols = [
+    { Tags: ["Lo-Fi", "chill"], lyrics: { style: ["Chill"] } },
+    { Tags: ["lo-fi"], lyrics: { style: [] } },
+  ];
+
+  const stats = buildTagStats(smols);
+  const keys = stats.map((tag) => tag.key).sort();
+
+  assert.deepEqual(keys, [normalizeTagKey("Chill"), normalizeTagKey("Lo-Fi")]);
+});
+
+test("mergeTagStats keeps snapshot tags even when live is smaller", () => {
+  const snapshotTags = [
+    { tag: "Lo-Fi", key: "lo-fi", count: 10, popularity: 20 },
+    { tag: "Chill", key: "chill", count: 5, popularity: 5 },
+  ];
+  const liveTags = [{ tag: "Lo-Fi", key: "lo-fi", count: 12, popularity: 30 }];
+
+  const merged = mergeTagStats(snapshotTags, liveTags);
+  const mergedKeys = merged.map((tag) => tag.key).sort();
+
+  assert.deepEqual(mergedKeys, ["chill", "lo-fi"]);
+});
+
+test("sortTagStats orders without filtering", () => {
+  const tags = [
+    { tag: "B", key: "b", count: 2, popularity: 5, latest: "2023-01-01" },
+    { tag: "A", key: "a", count: 3, popularity: 1, latest: "2024-01-01" },
+  ];
+
+  const alphabetical = sortTagStats(tags, "alphabetical");
+  const popularity = sortTagStats(tags, "popularity");
+  const recent = sortTagStats(tags, "recent");
+
+  assert.equal(alphabetical.length, tags.length);
+  assert.equal(popularity.length, tags.length);
+  assert.equal(recent.length, tags.length);
+  assert.equal(alphabetical[0].tag, "A");
+  assert.equal(popularity[0].tag, "B");
+  assert.equal(recent[0].tag, "A");
+});


### PR DESCRIPTION
### Motivation
- Replace fragile raw `PUBLIC_API_URL` fetch with the app's canonical smols fetch so live data parsing and headers match production behavior.  
- Prevent mismatched tag lists by ensuring the same live smols are used by both the unified tag provider and UI pages.  
- Restore loading state and add a producible diagnostics toggle so debugging can be enabled without a redeploy.  
- Reduce the chance of users seeing stale bundles by adding minimal cache headers for Cloudflare Pages-style deployments.  

### Description
- Updated `src/services/tags/unifiedTags.ts` to use `safeFetchSmols()`, accept an optional `liveSmols` injection, and add a `?debug=1` query toggle in `shouldLogTagDiagnostics()` instead of only allowing localhost/DEV.  
- Modified `src/components/tags/TagExplorer.svelte` to restore `isLoading`, fetch smols once via `safeFetchSmols()`, and pass the resulting `liveSmols` into `getUnifiedTags({ liveSmols })`.  
- Modified `src/components/radio/RadioBuilder.svelte` to avoid a second independent live fetch by reusing the smols loaded for the radio and calling `getUnifiedTags({ liveSmols })`, and to warn if final tag counts are unexpectedly smaller than snapshot counts.  
- Added `public/_headers` with conservative HTML cache policy and immutable caching for hashed assets to mitigate stale JS bundles; the tag-stat utilities and tests live in `src/utils/tagStats.js` and `tests/tagStats.test.js`.  

### Testing
- `node --test tests/tagStats.test.js tests/artistCollectedFeed.regression.test.js`