### PR TITLE
fix: Increase build memory limit to 4GB (OOM Fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "node --max-old-space-size=4096 ./node_modules/astro/astro.js build",
     "preview": "astro preview",
     "astro": "astro",
     "check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
## 🚒 BUILD FIX: OOM Resolution

**Issue:** Deployment failing with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`.
**Cause:** The new `smols-snapshot.json` (~2500 records) is too large for the default Node.js heap in the CI environment.
**Fix:** Explicitly increased the build process memory limit to **4GB** (`--max-old-space-size=4096`).

This should immediately resolve the build failure.

**Note:** This is an interim fix. Permanent resolution (Pagination/Batch API) is tracked in [smol-workflow#3](https://github.com/kalepail/smol-workflow/issues/3).