### PR TITLE
Fix scroll padding and auto-play in More Like This

### DIFF
--- a/src/components/search/SimilarSmols.svelte
+++ b/src/components/search/SimilarSmols.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
   import SmolCard from '../smol/SmolCard.svelte';
   import type { MixtapeTrack, SearchResult } from '../../types/domain';
   import { searchSimilarSmols } from '../../services/api/search';
   import { fetchLikedSmols } from '../../services/api/smols';
   import { addTrack } from '../../stores/mixtape.svelte';
   import { userState } from '../../stores/user.svelte';
+  import { audioState, selectSong, registerSongNextCallback } from '../../stores/audio.svelte';
 
   interface Props {
     id: string;
@@ -74,9 +76,26 @@
     error = null;
     void loadSimilar();
   });
+
+  function songNext() {
+    if (results.length === 0) return;
+    const currentId = audioState.currentSong?.Id;
+    const currentIndex = results.findIndex((s) => s.Id === currentId);
+    // If the current song is the last one (or not found in the list), stop
+    if (currentIndex === -1 || currentIndex >= results.length - 1) return;
+    selectSong(results[currentIndex + 1]);
+  }
+
+  onMount(() => {
+    registerSongNextCallback(songNext);
+  });
+
+  onDestroy(() => {
+    registerSongNextCallback(null);
+  });
 </script>
 
-<section class="px-2 py-8">
+<section class="px-2 py-8 pb-24">
   <div class="max-w-[1024px] mx-auto">
     <div class="mb-4">
       <h2 class="text-xl font-bold text-lime-400">More Like This</h2>


### PR DESCRIPTION
## Summary
- Adds bottom padding (`pb-24`) to the More Like This section so content isn't hidden behind the fixed audio player bar
- Registers a `songNextCallback` so songs in the More Like This list auto-play sequentially when one finishes
- Playback stops naturally after the last song in the list completes

## Test plan
- [ ] Navigate to a single song page with the audio player visible — verify you can scroll past the More Like This grid
- [ ] Play a song from the More Like This list — verify the next song auto-plays when it ends
- [ ] Play the last song in the list — verify playback stops after it finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)