### PR TITLE
[codex] Add public artist pages

### DIFF
--- a/src/components/ArtistPage.svelte
+++ b/src/components/ArtistPage.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import SmolGrid from './smol/SmolGrid.svelte';
+  import type { ArtistProfile } from '../types/api';
+  import { shortenAddress } from '../utils/address';
+
+  interface Props {
+    address: string;
+    artist?: ArtistProfile | null;
+  }
+
+  let { address, artist = null }: Props = $props();
+
+  const displayName = $derived(artist?.Username || shortenAddress(address));
+  const artistEndpoint = $derived(`artists/${encodeURIComponent(address)}/smols`);
+</script>
+
+<section class="border-b border-slate-800 bg-slate-900 px-2 py-8">
+  <div class="mx-auto max-w-[1024px]">
+    <p class="text-xs font-semibold uppercase tracking-wider text-lime-400">Artist</p>
+    <h1 class="mt-2 break-words text-3xl font-bold text-white">{displayName}</h1>
+    <p class="mt-2 break-all font-mono text-xs text-slate-400">{address}</p>
+  </div>
+</section>
+
+<SmolGrid
+  endpoint={artistEndpoint}
+  emptyTitle={`No public smols from ${displayName} yet`}
+  emptyDescription="Check back later."
+/>

--- a/src/components/Leaderboard.svelte
+++ b/src/components/Leaderboard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount } from 'svelte';
     import { logger } from '../utils/logger';
+    import { shortenAddress } from '../utils/address';
 
     // Interface for individual song data expected via props
     interface SmolData {
@@ -219,7 +220,14 @@
                                 {#each leaderboardData as entry, index (entry.address)}
                                     <tr class="hover:bg-slate-750 transition-colors duration-150">
                                         <td class="py-3 px-4 text-slate-300 whitespace-nowrap" style="width: 100px;">{index + 1}</td>
-                                        <td class="py-3 px-4 font-medium whitespace-nowrap" style="width: 140px;">{entry.username}</td>
+                                        <td class="py-3 px-4 font-medium whitespace-nowrap" style="width: 140px;">
+                                            <a
+                                                class="text-lime-300 hover:underline"
+                                                href={`/artists/${encodeURIComponent(entry.address)}`}
+                                            >
+                                                {entry.username || shortenAddress(entry.address)}
+                                            </a>
+                                        </td>
                                         <td class="py-3 px-4 text-right text-slate-300 whitespace-nowrap" style="width: 180px;">{entry.songCount.toLocaleString()}</td>
                                         <td class="py-3 px-4 text-right text-slate-300 whitespace-nowrap" style="width: 160px;">{entry.totalViews.toLocaleString()}</td>
                                         <td class="py-3 px-4 text-right text-slate-300 whitespace-nowrap" style="width: 160px;">{entry.totalPlays.toLocaleString()}</td>

--- a/src/components/smol/SmolCard.svelte
+++ b/src/components/smol/SmolCard.svelte
@@ -4,6 +4,7 @@
   import MiniAudioPlayer from '../audio/MiniAudioPlayer.svelte';
   import { audioState, selectSong, togglePlayPause } from '../../stores/audio.svelte';
   import { mixtapeModeState, mixtapeTrackIds } from '../../stores/mixtape.svelte';
+  import { shortenAddress } from '../../utils/address';
 
   interface Props {
     smol: Smol;
@@ -34,6 +35,12 @@
   }
 
   const isInMixtape = $derived(mixtapeTrackIds.current.has(smol.Id));
+  const creatorName = $derived(
+    smol.Creator ?? smol.Username ?? smol.artist ?? smol.author ?? shortenAddress(smol.Address)
+  );
+  const artistHref = $derived(
+    smol.Address ? `/artists/${encodeURIComponent(smol.Address)}` : null
+  );
 </script>
 
 <div
@@ -88,19 +95,31 @@
   </div>
 
   <div
-    class="flex items-center relative p-2 flex-1 overflow-hidden cursor-pointer"
+    class="flex min-h-16 items-center relative p-2 flex-1 overflow-hidden cursor-pointer"
     onclick={toggleSongSelection}
   >
-    <h1 class="relative z-1 leading-4 text-sm text-white">
-      {smol.Title}
-    </h1>
+    <div class="relative z-1 min-w-0 flex-1 pr-2">
+      <h1 class="break-words text-sm leading-4 text-white">
+        {smol.Title}
+      </h1>
+      {#if artistHref}
+        <a
+          class="mt-1 block max-w-full truncate text-[11px] leading-3 text-lime-300 hover:underline"
+          href={artistHref}
+          aria-label={`View artist ${creatorName}`}
+          onclick={(event) => event.stopPropagation()}
+        >
+          by {creatorName}
+        </a>
+      {/if}
+    </div>
     <img
       class="absolute inset-0 z-0 opacity-80 scale-y-[-1] w-full h-full blur-lg pointer-events-none"
       src={`${import.meta.env.PUBLIC_API_URL}/image/${smol.Id}.png`}
       alt={smol.Title}
       loading="lazy"
     />
-    <div class="relative z-2 pl-2 ml-auto">
+    <div class="relative z-2 ml-auto">
       <MiniAudioPlayer
         id={smol.Id}
         playing_id={audioState.playingId}

--- a/src/components/smol/SmolDisplay.svelte
+++ b/src/components/smol/SmolDisplay.svelte
@@ -3,6 +3,7 @@
   import Loader from '../ui/Loader.svelte';
   import LikeButton from '../ui/LikeButton.svelte';
   import TokenBalancePill from '../ui/TokenBalancePill.svelte';
+  import { shortenAddress } from '../../utils/address';
 
   interface Props {
     id: string | null;
@@ -47,6 +48,10 @@
     onOpenTradeModal,
     onLikeChanged,
   }: Props = $props();
+
+  const artistName = $derived(
+    d1?.Creator ?? d1?.Username ?? d1?.artist ?? d1?.author ?? shortenAddress(d1?.Address)
+  );
 </script>
 
 <div class="px-2 py-10">
@@ -160,6 +165,18 @@
         <h1>Prompt:</h1>
         <p>{kv_do && kv_do?.payload?.prompt}</p>
       </li>
+
+      {#if d1?.Address}
+        <li>
+          <h1>Artist:</h1>
+          <a
+            class="break-all text-lime-400 hover:underline"
+            href={`/artists/${encodeURIComponent(d1.Address)}`}
+          >
+            {artistName}
+          </a>
+        </li>
+      {/if}
 
       {#if kv_do?.image}
         <li>

--- a/src/components/smol/SmolGrid.svelte
+++ b/src/components/smol/SmolGrid.svelte
@@ -6,19 +6,25 @@
   import { mixtapeDraftState, mixtapeModeState, addTrack } from '../../stores/mixtape.svelte';
   import { userState } from '../../stores/user.svelte';
   import { fetchLikedSmols } from '../../services/api/smols';
+  import { fetchWithTimeout, throwIfNotOk } from '../../services/api/fetch';
   import { useVisibilityTracking } from '../../hooks/useVisibilityTracking';
   import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
   import { useGridMediaSession } from '../../hooks/useGridMediaSession';
   import { logger } from '../../utils/logger';
+  import type { ArtistProfile, SmolListResponse } from '../../types/api';
 
   interface Props {
     playlist?: string | null;
     endpoint?: string;
+    emptyTitle?: string;
+    emptyDescription?: string;
   }
 
   let {
     playlist = null,
-    endpoint = ''
+    endpoint = '',
+    emptyTitle = 'No smols yet',
+    emptyDescription = ''
   }: Props = $props();
 
   let results = $state<Smol[]>([]);
@@ -30,11 +36,54 @@
   let draggingId = $state<string | null>(null);
   let visibleCards = $state<Record<string, boolean>>({});
   let loadingMore = $state(false);
+  let paginationError = $state<string | null>(null);
   let scrollTrigger = $state<HTMLDivElement | null>(null);
 
   const visibilityHook = useVisibilityTracking();
   const scrollHook = useInfiniteScroll();
   const mediaHook = useGridMediaSession();
+
+  function buildSmolListUrl(cursorValue?: string | null) {
+    const cleanEndpoint = endpoint.replace(/^\/+/, '');
+    const baseUrl = cleanEndpoint
+      ? `${import.meta.env.PUBLIC_API_URL}/${cleanEndpoint}`
+      : import.meta.env.PUBLIC_API_URL;
+    const url = new URL(baseUrl, window.location.origin);
+
+    url.searchParams.set('limit', '100');
+    if (cursorValue) {
+      url.searchParams.set('cursor', cursorValue);
+    }
+
+    return url;
+  }
+
+  function applyUsernames(smols: Smol[], users?: ArtistProfile[]) {
+    if (!users?.length) return smols;
+
+    const usersByAddress = new Map(users.map((user) => [user.Address, user]));
+    return smols.map((smol) => {
+      if (!smol.Address || smol.Username) return smol;
+      const user = usersByAddress.get(smol.Address);
+      return user ? { ...smol, Username: user.Username } : smol;
+    });
+  }
+
+  function readSmolList(data: SmolListResponse | Smol[]) {
+    if (Array.isArray(data)) {
+      return {
+        smols: data,
+        nextCursor: null,
+        hasMore: false
+      };
+    }
+
+    return {
+      smols: applyUsernames(data.smols || [], data.users),
+      nextCursor: data.pagination?.nextCursor || null,
+      hasMore: data.pagination?.hasMore || false
+    };
+  }
 
   const observeVisibility = visibilityHook.createVisibilityObserver(
     (id) => {
@@ -48,25 +97,17 @@
   async function fetchInitialData() {
     loading = true;
     error = null;
+    paginationError = null;
 
     try {
-      // Fetch smols
-      const baseUrl = endpoint
-        ? `${import.meta.env.PUBLIC_API_URL}/${endpoint}`
-        : import.meta.env.PUBLIC_API_URL;
-      const url = new URL(baseUrl, window.location.origin);
-      url.searchParams.set('limit', '100');
+      const url = buildSmolListUrl();
+      const response = await fetchWithTimeout(url, { credentials: 'include' });
+      await throwIfNotOk(response, url.toString());
 
-      const response = await fetch(url, { credentials: 'include' });
-
-      if (!response.ok) {
-        throw new Error('Failed to load smols');
-      }
-
-      const data = await response.json();
-      results = data.smols || [];
-      cursor = data.pagination?.nextCursor || null;
-      hasMore = data.pagination?.hasMore || false;
+      const data = readSmolList(await response.json());
+      results = data.smols;
+      cursor = data.nextCursor;
+      hasMore = data.hasMore;
 
       // Fetch likes if user is authenticated (non-critical — fall back to empty)
       if (userState.contractId) {
@@ -186,38 +227,38 @@
   }
 
   async function loadMore() {
-    if (loadingMore || !hasMore || !cursor) return;
+    if (loadingMore || !hasMore) return;
+
+    if (!cursor) {
+      paginationError = 'More smols are unavailable right now.';
+      hasMore = false;
+      return;
+    }
 
     loadingMore = true;
+    paginationError = null;
 
     try {
-      const baseUrl = endpoint
-        ? `${import.meta.env.PUBLIC_API_URL}/${endpoint}`
-        : import.meta.env.PUBLIC_API_URL;
-      const url = new URL(baseUrl, window.location.origin);
-      url.searchParams.set('limit', '100');
-      url.searchParams.set('cursor', cursor);
-
-      const response = await fetch(url, {
+      const url = buildSmolListUrl(cursor);
+      const response = await fetchWithTimeout(url, {
         credentials: 'include'
       });
 
-      if (response.ok) {
-        const data = await response.json();
-        const newSmols = data.smols || [];
+      await throwIfNotOk(response, url.toString());
 
-        // Map likes to new smols
-        const smolsWithLikes = newSmols.map((smol: Smol) => ({
-          ...smol,
-          Liked: likes.some((id) => id === smol.Id)
-        }));
+      const data = readSmolList(await response.json());
+      const smolsWithLikes = data.smols.map((smol: Smol) => ({
+        ...smol,
+        Liked: likes.some((id) => id === smol.Id)
+      }));
 
-        results = [...results, ...smolsWithLikes];
-        cursor = data.pagination?.nextCursor || null;
-        hasMore = data.pagination?.hasMore || false;
-      }
-    } catch (error) {
-      logger.error('smol', 'Failed to load more smols:', error);
+      results = [...results, ...smolsWithLikes];
+      cursor = data.nextCursor;
+      hasMore = data.hasMore;
+    } catch (err) {
+      paginationError = err instanceof Error ? err.message : 'Failed to load more smols';
+      hasMore = false;
+      logger.error('smol', 'Failed to load more smols:', err);
     } finally {
       loadingMore = false;
     }
@@ -229,8 +270,25 @@
     <div class="text-lime-500">Loading...</div>
   </div>
 {:else if error}
-  <div class="flex justify-center items-center py-20">
-    <div class="text-red-500">{error}</div>
+  <div class="flex justify-center items-center px-2 py-20 text-center">
+    <div>
+      <div class="text-red-500">{error}</div>
+      <button
+        class="mt-4 rounded border border-lime-400 px-3 py-1 text-sm text-lime-300 hover:bg-lime-400/10"
+        onclick={fetchInitialData}
+      >
+        Retry
+      </button>
+    </div>
+  </div>
+{:else if results.length === 0}
+  <div class="flex justify-center px-2 py-20 text-center">
+    <div>
+      <h2 class="text-lg font-semibold text-white">{emptyTitle}</h2>
+      {#if emptyDescription}
+        <p class="mt-2 text-sm text-slate-400">{emptyDescription}</p>
+      {/if}
+    </div>
   </div>
 {:else}
   <div
@@ -252,7 +310,13 @@
   </div>
 {/if}
 
-{#if hasMore || loadingMore}
+{#if paginationError}
+  <div class="flex justify-center px-2 pb-20 text-center text-sm text-red-400">
+    {paginationError}
+  </div>
+{/if}
+
+{#if (hasMore && cursor) || loadingMore}
   <div bind:this={scrollTrigger} class="flex justify-center mb-20 py-8">
     {#if loadingMore}
       <div class="text-lime-500">Loading...</div>

--- a/src/pages/artists/[address].astro
+++ b/src/pages/artists/[address].astro
@@ -1,0 +1,36 @@
+---
+import ArtistPage from "../../components/ArtistPage.svelte";
+import Layout from "../../layouts/Layout.astro";
+import { fetchArtistSmols } from "../../services/api/artists";
+import { ApiError } from "../../services/api/fetch";
+import type { ArtistProfile } from "../../types/api";
+import { shortenAddress } from "../../utils/address";
+
+const { address } = Astro.params;
+
+let artist: ArtistProfile | null = null;
+
+if (address) {
+	try {
+		const data = await fetchArtistSmols(address, {
+			limit: 100,
+			cookie: Astro.request.headers.get("cookie") ?? undefined,
+		});
+		artist = data.artist;
+	} catch (error) {
+		if (!(error instanceof ApiError && error.status === 404)) {
+			console.error("Failed to fetch artist meta data:", error);
+		}
+	}
+}
+
+const displayName = artist?.Username || shortenAddress(address);
+const title = displayName ? `Smol - ${displayName}` : "Smol - Artist";
+const description = displayName
+	? `Public smols by ${displayName}`
+	: "Public smols by artist";
+---
+
+<Layout {title} {description}>
+	<ArtistPage address={address ?? ""} {artist} client:only="svelte" />
+</Layout>

--- a/src/services/api/artists.ts
+++ b/src/services/api/artists.ts
@@ -1,0 +1,28 @@
+import type { ArtistSmolsResponse } from '../../types/api';
+import { fetchWithTimeout, throwIfNotOk } from './fetch';
+
+const API_URL = import.meta.env.PUBLIC_API_URL;
+
+interface FetchArtistSmolsOptions {
+  limit?: number;
+  cursor?: string | null;
+  cookie?: string;
+  signal?: AbortSignal;
+}
+
+export async function fetchArtistSmols(
+  address: string,
+  { limit = 100, cursor = null, cookie, signal }: FetchArtistSmolsOptions = {}
+): Promise<ArtistSmolsResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor) params.set('cursor', cursor);
+
+  const endpoint = `${API_URL}/artists/${encodeURIComponent(address)}/smols?${params}`;
+  const response = await fetchWithTimeout(endpoint, {
+    headers: cookie ? { Cookie: cookie } : undefined,
+    signal,
+  });
+
+  await throwIfNotOk(response, endpoint);
+  return response.json();
+}

--- a/src/services/api/fetch.ts
+++ b/src/services/api/fetch.ts
@@ -20,7 +20,8 @@ export class ApiError extends Error {
  */
 export async function throwIfNotOk(response: Response, endpoint: string): Promise<void> {
   if (response.ok) return;
-  const body = (await response.text().catch(() => '')) || response.statusText;
+  const fallback = response.statusText || `Request failed with status ${response.status}`;
+  const body = (await response.text().catch(() => '')) || fallback;
   throw new ApiError(response.status, body, endpoint);
 }
 
@@ -60,9 +61,8 @@ function rawFetch(
 /**
  * Fetch with an automatic AbortController timeout.
  *
- * GET requests to the same URL are deduplicated — if an identical GET is
- * already in-flight the existing promise is returned instead of firing a
- * second request.
+ * Simple public GET requests to the same URL are deduplicated.
+ * Auth/cookie-bearing requests are never deduplicated across callers.
  */
 export function fetchWithTimeout(
   input: RequestInfo | URL,
@@ -70,11 +70,14 @@ export function fetchWithTimeout(
 ): Promise<Response> {
   const method = (init?.method ?? 'GET').toUpperCase();
   const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  const canDeduplicate =
+    method === 'GET' && !init?.signal && !init?.headers && !init?.credentials;
 
-  // Only deduplicate simple GET requests (no custom signal — those are caller-controlled)
-  if (method === 'GET' && !init?.signal) {
+  // Only deduplicate simple public GET requests. Auth/cookie-bearing requests
+  // can vary by caller even when the URL is identical.
+  if (canDeduplicate) {
     const existing = inflightGets.get(url);
-    if (existing) return existing;
+    if (existing) return existing.then((response) => response.clone());
 
     const promise = rawFetch(input, init).finally(() => {
       inflightGets.delete(url);
@@ -85,7 +88,7 @@ export function fetchWithTimeout(
     // Failsafe: remove the entry after 60s even if the promise never settles
     setTimeout(() => inflightGets.delete(url), 60_000);
 
-    return promise;
+    return promise.then((response) => response.clone());
   }
 
   return rawFetch(input, init);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -21,6 +21,28 @@ export interface FetchSmolsResponse extends Array<Smol> {}
 
 export interface FetchLikesResponse extends Array<string> {}
 
+export interface Pagination {
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+export interface ArtistProfile {
+  Username: string;
+  Address: string;
+}
+
+export interface SmolListResponse {
+  smols: Smol[];
+  users?: ArtistProfile[];
+  pagination?: Pagination;
+}
+
+export interface ArtistSmolsResponse extends SmolListResponse {
+  artist: ArtistProfile | null;
+  users: ArtistProfile[];
+  pagination: Pagination;
+}
+
 export interface LikeRequest {
   smolId: string;
 }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -73,6 +73,9 @@ export interface SmolDetailResponse {
     Title: string;
     Address?: string;
     Creator?: string;
+    Username?: string;
+    artist?: string;
+    author?: string;
     Song_1?: string;
     Public?: number;
     Mint_Token?: string;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,5 @@
+export function shortenAddress(address?: string | null, head = 6, tail = 4): string {
+  if (!address) return '';
+  if (address.length <= head + tail + 3) return address;
+  return `${address.slice(0, head)}...${address.slice(-tail)}`;
+}


### PR DESCRIPTION
## Summary
- Add a public `/artists/:address` page backed by `GET /artists/:address/smols`.
- Reuse `SmolGrid` for arbitrary list endpoints with empty states, retry UI, pagination error handling, and username hydration from the response `users` array.
- Add artist links from smol cards, smol detail pages, and leaderboard usernames.
- Harden shared fetch behavior so auth/cookie requests are not URL-deduped and deduped public responses are cloned before consumption.

## Validation
- `pnpm check`
- `pnpm build`
- `agent-browser` QA against local dev server and deployed backend:
  - `/artists/CC7X62SMHZMZXU6M3IZ7ODXBR4JBW2C3ZYRW6JPWA3RFVWXKUFWXTQMC` renders artist `hermes2c02578` and public smol cards.
  - Card artist links point back to the artist route and use the `users` response metadata for display names.
  - Smol detail page renders an Artist link and navigates back to the artist route.
  - Unknown artist route renders the clean empty state from `artist: null`, `smols: []`.
  - Browser network log shows `GET https://api.smol.xyz/artists/.../smols?limit=100` returning `200` and image assets returning `200`.