### PR TITLE
fix: hide repeated creators on artist grids

### DIFF
--- a/src/components/ArtistPage.svelte
+++ b/src/components/ArtistPage.svelte
@@ -26,4 +26,5 @@
   endpoint={artistEndpoint}
   emptyTitle={`No public smols from ${displayName} yet`}
   emptyDescription="Check back later."
+  showCreators={false}
 />

--- a/src/components/smol/SmolCard.svelte
+++ b/src/components/smol/SmolCard.svelte
@@ -14,6 +14,7 @@
     onDragStart?: (event: DragEvent) => void;
     onDragEnd?: () => void;
     isDragging?: boolean;
+    showCreator?: boolean;
   }
 
   let {
@@ -23,7 +24,8 @@
     onAddToMixtape,
     onDragStart,
     onDragEnd,
-    isDragging = false
+    isDragging = false,
+    showCreator = true
   }: Props = $props();
 
   function toggleSongSelection() {
@@ -102,7 +104,7 @@
       <h1 class="break-words text-sm leading-4 text-white">
         {smol.Title}
       </h1>
-      {#if artistHref}
+      {#if showCreator && artistHref}
         <a
           class="mt-1 block max-w-full truncate text-[11px] leading-3 text-lime-300 hover:underline"
           href={artistHref}

--- a/src/components/smol/SmolGrid.svelte
+++ b/src/components/smol/SmolGrid.svelte
@@ -18,13 +18,15 @@
     endpoint?: string;
     emptyTitle?: string;
     emptyDescription?: string;
+    showCreators?: boolean;
   }
 
   let {
     playlist = null,
     endpoint = '',
     emptyTitle = 'No smols yet',
-    emptyDescription = ''
+    emptyDescription = '',
+    showCreators = true
   }: Props = $props();
 
   let results = $state<Smol[]>([]);
@@ -304,6 +306,7 @@
           onDragStart={(e) => handleDragStart(e, smol)}
           onDragEnd={handleDragEnd}
           isDragging={draggingId === smol.Id}
+          showCreator={showCreators}
         />
       </div>
     {/each}


### PR DESCRIPTION
## Summary
- add a card/grid option to hide creator metadata
- suppress repeated creator links on public artist pages only

## Verification
- pnpm check
- pnpm build
- agent-browser local artist page snapshot confirmed cards no longer show repeated creator labels